### PR TITLE
[Fix] Invalid Formatter import & Annotation Manifest conflicts

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -21,7 +21,7 @@ project.ext {
     description = 'Static code analysis plugin for Android projects.'
     groupId = 'pt.simdea.verifier'
     artifactId = 'verifier'
-    version = "3.5.7"
+    version = "3.5.8"
     website = 'https://github.com/simdea/android-quality-verifier'
     scm = 'https://github.com/simdea/android-quality-verifier'
     tags = ['android', 'verifier', 'check', 'checkstyle', 'findbugs', 'pmd', 'lint', 'quality']

--- a/plugin/src/main/groovy/pt/simdea/verifier/CheckPlugin.groovy
+++ b/plugin/src/main/groovy/pt/simdea/verifier/CheckPlugin.groovy
@@ -15,8 +15,8 @@ class CheckPlugin implements Plugin<Project> {
         target.check.extensions.create('lint', CheckExtension.Lint)
 
         target.repositories.add(target.getRepositories().jcenter())
-        target.dependencies.add("compile", "pt.simdea.verifier.annotations:verifier-annotations:0.0.2")
-        target.dependencies.add("annotationProcessor", "pt.simdea.verifier.annotations:verifier-annotations:0.0.2")
+        target.dependencies.add("compile", "pt.simdea.verifier.annotations:verifier-annotations:0.0.3")
+        target.dependencies.add("annotationProcessor", "pt.simdea.verifier.annotations:verifier-annotations:0.0.3")
 
         new FindbugsCheck().apply(target)
         new PmdCheck().apply(target)

--- a/plugin/src/main/groovy/pt/simdea/verifier/checkstyle/CheckstyleCheck.groovy
+++ b/plugin/src/main/groovy/pt/simdea/verifier/checkstyle/CheckstyleCheck.groovy
@@ -1,6 +1,7 @@
 package pt.simdea.verifier.checkstyle
 
 import com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask
+import com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask.Formatter
 import com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask.FormatterType
 import groovy.util.slurpersupport.GPathResult
 import org.gradle.api.Project

--- a/verifier-annotations/build.gradle
+++ b/verifier-annotations/build.gradle
@@ -81,7 +81,7 @@ publish {
     userOrg = 'simdea'
     groupId = 'pt.simdea.verifier.annotations'
     artifactId = 'verifier-annotations'
-    publishVersion = '0.0.2'
+    publishVersion = '0.0.3'
     repoName = 'android-quality-verifier'
     repository = project.ext.scm
     issueTracker = "${project.ext.scm}/issues"

--- a/verifier-annotations/src/main/AndroidManifest.xml
+++ b/verifier-annotations/src/main/AndroidManifest.xml
@@ -3,11 +3,6 @@
           package="pt.simdea.verifier.annotations"
 >
 
-    <application android:allowBackup="true"
-                 android:label="@string/app_name"
-                 android:supportsRtl="true"
-    >
-
-    </application>
+    <application />
 
 </manifest>


### PR DESCRIPTION
Here's a fix for the invalid Formatter import statement which is removed by a previous commit along with a fix for Annotation Library manifest conflicts